### PR TITLE
Debug buffer deadlock

### DIFF
--- a/src/buffer/manager.rs
+++ b/src/buffer/manager.rs
@@ -150,7 +150,7 @@ impl BufferManager {
             return Err(BufferError::PageDiskDNE);
         }
 
-        // Acquire locks for page table and type chart (in this order).
+        // Acquire latches for page table and type chart (in this order).
         let mut page_table = self.page_table.lock().unwrap();
         let type_chart = self.type_chart.read().unwrap();
 

--- a/src/buffer/manager.rs
+++ b/src/buffer/manager.rs
@@ -8,7 +8,7 @@ use crate::buffer::replacement::lru::LRUReplacer;
 use crate::buffer::replacement::slow::SlowReplacer;
 use crate::buffer::replacement::{PageReplacer, ReplacerAlgorithm};
 use crate::buffer::{Buffer, FrameArc, FrameRLatch, FrameWLatch};
-use crate::common::{BufferFrameIdT, PageIdT, BUFFER_SIZE, CLASSIFIER_PAGE_ID};
+use crate::common::{BufferFrameIdT, PageIdT, BUFFER_SIZE, CLASSIFIER_PAGE_ID, DICTIONARY_PAGE_ID};
 use crate::disk::manager::DiskManager;
 use crate::page::classifier_page::ClassifierPage;
 use crate::page::{init_page_variant, Page, PageVariant};
@@ -68,6 +68,9 @@ impl BufferManager {
         for (page_id, page_type) in classifier {
             type_chart.insert(page_id, page_type);
         }
+
+        type_chart.insert(DICTIONARY_PAGE_ID, PageVariant::Dictionary);
+        type_chart.insert(CLASSIFIER_PAGE_ID, PageVariant::Classifier);
 
         Self {
             buffer: Buffer::new(buffer_size),

--- a/src/buffer/replacement/slow.rs
+++ b/src/buffer/replacement/slow.rs
@@ -60,6 +60,7 @@ impl PageReplacer for SlowReplacer {
 
     fn unpin(&self, frame_id: u32) {
         let mut queue = self.queue.lock().unwrap();
+
         let count = queue
             .iter()
             .filter(|id| **id == frame_id)

--- a/src/page/relation_page.rs
+++ b/src/page/relation_page.rs
@@ -4,7 +4,7 @@
  */
 
 use crate::common::io::{read_u32, write_u32};
-use crate::common::{LsnT, PAGE_SIZE};
+use crate::common::{LsnT, PageIdT, PAGE_SIZE};
 use crate::page::{Page, PageError, PageVariant};
 use crate::relation::record::Record;
 
@@ -113,22 +113,26 @@ impl RelationPage {
     }
 
     /// Set the page ID.
-    pub fn set_page_id(&mut self, id: u32) {
+    pub fn set_page_id(&mut self, id: PageIdT) {
         write_u32(&mut self.bytes, PAGE_ID_OFFSET, id).unwrap()
     }
 
     /// Get the previous page ID.
-    pub fn get_prev_page_id(&self) -> u32 {
-        read_u32(&self.bytes, PREV_PAGE_ID_OFFSET).unwrap()
+    pub fn get_prev_page_id(&self) -> Option<PageIdT> {
+        let pid = read_u32(&self.bytes, PREV_PAGE_ID_OFFSET).unwrap();
+        match pid == UNINITIALIZED {
+            true => None,
+            false => Some(pid),
+        }
     }
 
     /// Set the previous page ID.
-    pub fn set_prev_page_id(&mut self, id: u32) {
+    pub fn set_prev_page_id(&mut self, id: PageIdT) {
         write_u32(&mut self.bytes, PREV_PAGE_ID_OFFSET, id).unwrap()
     }
 
     /// Get the next page ID.
-    pub fn get_next_page_id(&self) -> Option<u32> {
+    pub fn get_next_page_id(&self) -> Option<PageIdT> {
         let pid = read_u32(&self.bytes, NEXT_PAGE_ID_OFFSET).unwrap();
         match pid == UNINITIALIZED {
             true => None,
@@ -137,7 +141,7 @@ impl RelationPage {
     }
 
     /// Set the next page ID.
-    pub fn set_next_page_id(&mut self, id: u32) {
+    pub fn set_next_page_id(&mut self, id: PageIdT) {
         write_u32(&mut self.bytes, NEXT_PAGE_ID_OFFSET, id).unwrap()
     }
 

--- a/src/relation/heap.rs
+++ b/src/relation/heap.rs
@@ -89,7 +89,7 @@ impl Heap {
                     page_id = pid
                 }
                 None => {
-                    // DROP write latch to current page BEFORE calling buffer manager to prevent
+                    // RELEASE write latch to current page BEFORE calling buffer manager to prevent
                     // deadlocks.
                     let prev_pid = page.get_id();
                     self.buffer_manager.unpin_w(frame);
@@ -110,7 +110,7 @@ impl Heap {
                     new_page.set_prev_page_id(prev_pid);
                     new_frame.set_dirty_flag(true);
 
-                    // DROP write latch to new page.
+                    // RELEASE write latch to new page.
                     self.buffer_manager.unpin_w(new_frame);
 
                     // ACQUIRE write latch to prev page, and add next page ID.
@@ -127,7 +127,7 @@ impl Heap {
                     prev_page.set_next_page_id(new_pid);
                     prev_frame.set_dirty_flag(true);
 
-                    // DROP write latch to prev page.
+                    // RELEASE write latch to prev page.
                     self.buffer_manager.unpin_w(prev_frame);
 
                     // Return inserted record ID.

--- a/src/relation/record.rs
+++ b/src/relation/record.rs
@@ -344,7 +344,7 @@ mod tests {
             None,
             Some(Box::new(7_654_321_i32)),
             Some(Box::new(-9_876_543_210_i64)),
-            None,
+            Some(Box::new(-5.4321_f32)),
             Some(Box::new("Hello, World!".to_string())),
         ];
         // Create a series of values that are NOT a valid instance of the schema.
@@ -386,6 +386,9 @@ mod tests {
 
         let value = record.get_value(2).unwrap();
         assert!(value.is_none());
+
+        let value = record.get_value(5).unwrap();
+        assert_eq!(value.unwrap().get_inner(), InnerValue::Decimal(-5.4321f32));
 
         let value = record.get_value(6).unwrap();
         assert_eq!(

--- a/tests/catalog.rs
+++ b/tests/catalog.rs
@@ -163,36 +163,6 @@ fn test_insert_many_records() {
                 abcdefghijklmnopqrstuvwxyz \
                 abcdefghijklmnopqrstuvwxyz \
                 abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
                 abcdefghijklmnopqrstuvwxyz"
                     .to_string(),
             )),
@@ -227,84 +197,36 @@ fn test_insert_many_records_in_parallel() {
         vec![
             Some(Box::new(0)),
             Some(Box::new(true)),
-            Some(Box::new(
-                "abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz \
-                abcdefghijklmnopqrstuvwxyz"
-                    .to_string(),
-            )),
+            Some(Box::new("Hello, World!".to_string())),
         ],
         ctx.schema_1.clone(),
     )
     .unwrap();
 
     let record_2 = Record::new(
-        vec![Some(Box::new(123456789)), Some(Box::new(true))],
+        vec![Some(Box::new(123456789_i32)), Some(Box::new(false))],
         ctx.schema_2.clone(),
     )
     .unwrap();
 
-    let num_threads = 20;
-    let mut handles = Vec::with_capacity(num_threads);
+    let mut handles = Vec::with_capacity(20);
 
     // Spin up several threads and simultaneously insert several records into both relations.
-    for _ in 0..1 {
+    for _ in 0..10 {
         let relation = relation_1.clone();
         let record = record_1.clone();
         handles.push(thread::spawn(move || {
-            for _ in 0..10 {
-                assert!(relation.insert_record(record.clone()).is_ok());
+            for _ in 0..100 {
+                relation.insert_record(record.clone()).unwrap();
             }
         }));
     }
-    for _ in 0..1 {
+    for _ in 0..10 {
         let relation = relation_2.clone();
         let record = record_2.clone();
         handles.push(thread::spawn(move || {
-            for _ in 0..10 {
-                assert!(relation.insert_record(record.clone()).is_ok());
+            for _ in 0..100 {
+                relation.insert_record(record.clone()).unwrap();
             }
         }));
     }

--- a/tests/catalog.rs
+++ b/tests/catalog.rs
@@ -210,7 +210,7 @@ fn test_insert_many_records_in_parallel() {
     .unwrap();
 
     let num_threads = 20;
-    let num_inserts_per_thread = 1000;
+    let num_inserts_per_thread = 100;
     let mut handles = Vec::with_capacity(num_threads);
 
     // Spin up several threads and simultaneously insert several records into both relations.

--- a/tests/catalog.rs
+++ b/tests/catalog.rs
@@ -209,23 +209,25 @@ fn test_insert_many_records_in_parallel() {
     )
     .unwrap();
 
-    let mut handles = Vec::with_capacity(20);
+    let num_threads = 20;
+    let num_inserts_per_thread = 1000;
+    let mut handles = Vec::with_capacity(num_threads);
 
     // Spin up several threads and simultaneously insert several records into both relations.
-    for _ in 0..10 {
+    for _ in 0..num_threads / 2 {
         let relation = relation_1.clone();
         let record = record_1.clone();
         handles.push(thread::spawn(move || {
-            for _ in 0..100 {
+            for _ in 0..num_inserts_per_thread {
                 relation.insert_record(record.clone()).unwrap();
             }
         }));
     }
-    for _ in 0..10 {
+    for _ in 0..num_threads / 2 {
         let relation = relation_2.clone();
         let record = record_2.clone();
         handles.push(thread::spawn(move || {
-            for _ in 0..100 {
+            for _ in 0..num_inserts_per_thread {
                 relation.insert_record(record.clone()).unwrap();
             }
         }));

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -7,5 +7,5 @@ use jin::common::{BufferFrameIdT, RelationIdT, CLASSIFIER_PAGE_ID};
 
 /// Constants used for testing
 pub const TEST_DB_FILENAME: &str = "test_db.jin";
-pub const TEST_BUFFER_SIZE: BufferFrameIdT = 4;
+pub const TEST_BUFFER_SIZE: BufferFrameIdT = 64;
 pub const FIRST_RELATION_PAGE_ID: RelationIdT = CLASSIFIER_PAGE_ID + 1;


### PR DESCRIPTION
# Objective
Fix various bugs and deadlocks that occur when executing many insertions on many threads into multiple tables. (Ex. 20 threads, 1000 inserts/thread, 2 tables). Increasing the workload/number of threads should simply increase the execution time, and nothing more.

# Result
~~Most~~ _All_ major bugs that caused deadlocks have been resolved. 200 threads, 1000 inserts/thread, 2 tables has been confirmed to execute correctly without locking (although currently really slow due to small buffer size, page replacer implementaton, and no access method optimization for pages).

# Work to do
There was one instance where the program crashed during insertion with a large number of threads ~~but I haven't been able to reproduce the crash since~~ _due to the buffer being full/all pages pinned._ ~~May have hit some obscure corner case so I'll debug that going forward.~~ I also have an issue where increasing the buffer size slows down execution time (see benchmarks below). My hunch is the the O(N) pin/unpin operations for the current dummy page replacer, but will have to do more testing to find out.

 # Benchmarks
Below are some really rough benchmarks for execution time with 20 threads, 1000 inserts per thread, 2 tables on a Macbook Pro 16 inch with a 2.4 GHz 8-Core Intel Core i9 CPU and 32GB memory. I simply ran `time cargo test -- --exact test_insert_many_records_in_parallel` with 1 attempt each so take each benchmark with a grain of salt.

* Buffer size 4: `11.49s user 10.82s system 114% cpu 19.547 total`
* Buffer size 16: `10.60s user 8.39s system 118% cpu 16.052 total`
* Buffer size 64: `10.78s user 5.05s system 131% cpu 12.020 total`
* Buffer size 128: `14.59s user 4.46s system 125% cpu 15.123 total`
* Buffer size 256: `22.94s user 4.45s system 117% cpu 23.400 total`
